### PR TITLE
feat (infra): [network] disable default outbound access

### DIFF
--- a/infra-as-code/bicep/network.bicep
+++ b/infra-as-code/bicep/network.bicep
@@ -60,6 +60,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2024-01-01' existing = {
   resource appServiceSubnet 'subnets' = {
     name: 'snet-appServicePlan'
     properties: {
+      defaultOutboundAccess: false
       addressPrefix: appServicesSubnetAddressPrefix
       networkSecurityGroup: {
         id: appServiceSubnetNsg.id
@@ -81,6 +82,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2024-01-01' existing = {
   resource appGatewaySubnet 'subnets' = {
     name: 'snet-appGateway'
     properties: {
+      defaultOutboundAccess: false
       addressPrefix: appGatewaySubnetAddressPrefix
       networkSecurityGroup: {
         id: appGatewaySubnetNsg.id


### PR DESCRIPTION
## WHY

we wanted to explicitly disable outbound access, means no default outbound access from all subnet where changing this setting is allowed. We wanted to ensure that AIFoundry baseline is working and enforcing this setup since default access is being retired on September 2025

## WHAT Changed

- `app service` and `app-gateway`  subnets are now marked with default outbound access as `false` 

## TEST

<img width="862" height="1034" alt="image" src="https://github.com/user-attachments/assets/7d2edf28-7d36-468c-b68e-21a4b5fef338" />
<img width="2188" height="1070" alt="image" src="https://github.com/user-attachments/assets/8f399240-a31e-4b90-a509-f98b1086eaac" />


