### PR TITLE
feat (infra): [aifoundry] add resource locks for AI Foundry Project Capability Host dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,14 @@ Most Azure resources deployed in the prior steps will incur ongoing charges unle
 
 Additionally, a few of the resources deployed enter soft delete status which will restrict the ability to redeploy another resource with the same name or DNS entry; and might not release quota. It's best to purge any soft deleted resources once you are done exploring. Use the following commands to delete the deployed resources and resource group and to purge each of the resources with soft delete.
 
+1. Delete the resource level locks for AI Foundry Project Capability Host dependencies
+
+   ```bash
+   az lock delete -g $RESOURCE_GROUP --resource-type 'Microsoft.Storage/storageAccounts' --resource stagent${BASE_NAME} -n stagent${BASE_NAME}-lock
+   az lock delete -g $RESOURCE_GROUP --resource-type 'Microsoft.DocumentDB/databaseAccounts' --resource cdb-ai-agent-threads-${BASE_NAME} -n cdb-ai-agent-threads-${BASE_NAME}-lock
+   az lock delete -g $RESOURCE_GROUP --resource-type 'Microsoft.Search/searchServices' --resource ais-ai-agent-vector-store-${BASE_NAME} -n ais-ai-agent-vector-store-${BASE_NAME}-lock
+   ```
+
 1. Delete the resource group as a way to delete all contained Azure resources.
 
    | :warning: | This will completely delete any data you may have included in this example. That data and this deployment will be unrecoverable. |

--- a/infra-as-code/bicep/ai-agent-blob-storage.bicep
+++ b/infra-as-code/bicep/ai-agent-blob-storage.bicep
@@ -154,6 +154,18 @@ resource azureDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-prev
   }
 }
 
+// Prevent Accidental Changes
+
+resource agentStorageAccountLocks 'Microsoft.Authorization/locks@2020-05-01' = {
+  scope: agentStorageAccount
+  name: '${agentStorageAccount.name}-lock'
+  properties: {
+    level: 'CanNotDelete'
+    notes: 'Prevent deleting; recovery not practical. Hard dependency for your AI Foundry Agent Service.'
+    owners: []
+  }
+}
+
 // ---- Outputs ----
 
 output storageAccountName string = agentStorageAccount.name

--- a/infra-as-code/bicep/ai-search.bicep
+++ b/infra-as-code/bicep/ai-search.bicep
@@ -119,6 +119,18 @@ resource aiSearchPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01'
   }
 }
 
+// Prevent Accidental Changes
+
+resource azureAiSearchServiceLocks 'Microsoft.Authorization/locks@2020-05-01' = {
+  scope: azureAiSearchService
+  name: '${azureAiSearchService.name}-lock'
+  properties: {
+    level: 'CanNotDelete'
+    notes: 'Prevent deleting; recovery not practical. Hard dependency for your AI Foundry Agent Service.'
+    owners: []
+  }
+}
+
 // ---- Outputs ----
 
 output aiSearchName string = azureAiSearchService.name

--- a/infra-as-code/bicep/cosmos-db.bicep
+++ b/infra-as-code/bicep/cosmos-db.bicep
@@ -184,6 +184,18 @@ resource assignDebugUserToCosmosAccountReader 'Microsoft.Authorization/roleAssig
   }
 }
 
+// Prevent Accidental Changes
+
+resource cosmosDbAccountLocks 'Microsoft.Authorization/locks@2020-05-01' = {
+  scope: cosmosDbAccount
+  name: '${cosmosDbAccount.name}-lock'
+  properties: {
+    level: 'CanNotDelete'
+    notes: 'Prevent deleting; recovery not practical. Hard dependency for your AI Foundry Agent Service.'
+    owners: []
+  }
+}
+
 // ---- Outputs ----
 
 output cosmosDbAccountName string = cosmosDbAccount.name


### PR DESCRIPTION
## WHY

We want to prevent accidental deletions of critical AI Foundry Project capability host dependencies that might cause disruption. This way we reduce the number of potential incidents that might affect this architecture.

## WHAT Change?

- add a cannot delete lock to Thread storage (Cosmos DB)
- add a cannot delete lock to Index/Knowlege storage (Storage Account)
- add a cannot delete lock to Vector store (AI Search Service)
- add instructions to delete resource level locks before cleaning up

## TEST

tested via https://github.com/Azure-Samples/azure-ai-foundry-baseline/pull/73